### PR TITLE
STEP8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2.23' #My Docker Compose version is 2.23.0
+
+#Define Docker services
+services:
+  api:
+    image: build2024/app:latest #Docker image used for api #STEP4
+    ports:
+      - "9000:9000" #port 9000 on host to 9000 of container
+    environment:
+      - FRONT_URL=http://localhost:3000
+
+  frontend:
+    image: build2024/web:latest
+    ports:
+      - "3000:3000" #map port 3000 on host to 3000 on container #STEP6
+    environment:
+      - REACT_APP_API_URL=http://localhost:9000

--- a/typescript/simple-mercari-web/dockerfile
+++ b/typescript/simple-mercari-web/dockerfile
@@ -1,7 +1,14 @@
 FROM node:20-alpine
 WORKDIR /app
 
+COPY . .
+
+RUN npm install
+
 RUN addgroup -S mercari && adduser -S trainee -G mercari
+RUN chown -R trainee:mercari /app
 USER trainee
 
-CMD ["node", "-v"]
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
## 8.1. (Revision) Building Docker Images
cd typescript/simple-mercari-web
docker build -t build2024/web:latest .
docker run -d -p 3000:3000 build2024/web:latest

## 8.2. Installing Docker Compose

## 8.3. Docker Compose Tutorial

## 8.4. Run frontend and API using Docker Compose
build venv
cd python
docker build -t build2024/web:latest .
cd typescript/simple-mercari-web
docker build -t build2024/app:latest .
docker-compose up

- It currently gives error because they can't open mercari.sqlite3 database
- Once STEP 6 is fixed, it should theoretically work

## Reflection
Had to make new branch so many times since I messed up, especially for deciding which branch to branch out from
St8 is the final one I went with ***

## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
